### PR TITLE
Add power command

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ For a complete overview of all of the available commands, run:
 
 Yes, please!
 
-You can create a new issue [here](https://github.com/masayukioguni/go-tugboat/issues/new). Thank you!
+You can create a new issue [here](https://github.com/masayukioguni/godo-cli/issues/new). Thank you!
 
 ## Contributing
 

--- a/command/config.go
+++ b/command/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/masayukioguni/godo-cli/config"
 	"github.com/mitchellh/cli"
+	"strconv"
 	"strings"
 )
 
@@ -28,6 +29,10 @@ Options:
   -image=int image id
   -size=string size slug ex:512mb
   -key=int SSHKey id 
+  -backups=bool 
+  -ipv6=bool 
+  -private_networking=bool 
+
 
 e.g.
   configuration
@@ -35,6 +40,8 @@ e.g.
 
   set region to config
     godo-cli config set -region=nyc3
+
+
 `
 	return strings.TrimSpace(helpText)
 }
@@ -46,11 +53,17 @@ func (c *ConfigCommand) Set(args []string) int {
 	var image string
 	var size string
 	var key string
+	var backups string
+	var ipv6 string
+	var private_networking string
 
 	cmdFlags.StringVar(&region, "region", "", "")
 	cmdFlags.StringVar(&image, "image", "", "")
 	cmdFlags.StringVar(&size, "size", "", "")
 	cmdFlags.StringVar(&key, "key", "", "")
+	cmdFlags.StringVar(&backups, "backups", "", "")
+	cmdFlags.StringVar(&ipv6, "ipv6", "", "")
+	cmdFlags.StringVar(&private_networking, "private_networking", "", "")
 
 	err := cmdFlags.Parse(args)
 
@@ -73,6 +86,18 @@ func (c *ConfigCommand) Set(args []string) int {
 
 	if key != "" {
 		c.Config.Defaults.Key = key
+	}
+
+	if backups != "" {
+		c.Config.Defaults.Backups, _ = strconv.ParseBool(backups)
+	}
+
+	if ipv6 != "" {
+		c.Config.Defaults.IPv6, _ = strconv.ParseBool(ipv6)
+	}
+
+	if private_networking != "" {
+		c.Config.Defaults.PrivateNetworking, _ = strconv.ParseBool(private_networking)
 	}
 
 	savePath, err := config.GetConfigPath()
@@ -101,6 +126,10 @@ func (c *ConfigCommand) Get(args []string) int {
 	c.Ui.Output(fmt.Sprintf("Size: %v", c.Config.Defaults.Size))
 	c.Ui.Output(fmt.Sprintf("Region: %v", c.Config.Defaults.Region))
 	c.Ui.Output(fmt.Sprintf("Key: %v", c.Config.Defaults.Key))
+	c.Ui.Output(fmt.Sprintf("Backups: %v", c.Config.Defaults.Backups))
+	c.Ui.Output(fmt.Sprintf("IPv6: %v", c.Config.Defaults.IPv6))
+	c.Ui.Output(fmt.Sprintf("PrivateNetworking: %v", c.Config.Defaults.PrivateNetworking))
+
 	return 0
 }
 

--- a/command/create.go
+++ b/command/create.go
@@ -35,11 +35,14 @@ e.g.
 }
 
 type CreateFlags struct {
-	Name   string
-	Image  string
-	Size   string
-	Region string
-	Key    string
+	Name              string
+	Image             string
+	Size              string
+	Region            string
+	Key               string
+	Backups           bool
+	IPv6              bool
+	PrivateNetworking bool
 }
 
 func (c *CreateCommand) parse(args []string) (*CreateFlags, error) {
@@ -52,6 +55,9 @@ func (c *CreateCommand) parse(args []string) (*CreateFlags, error) {
 	cmdFlags.StringVar(&flags.Image, "image", c.Config.Defaults.Image, "")
 	cmdFlags.StringVar(&flags.Region, "region", c.Config.Defaults.Region, "")
 	cmdFlags.StringVar(&flags.Key, "key", c.Config.Defaults.Key, "")
+	cmdFlags.BoolVar(&flags.Backups, "backups", c.Config.Defaults.Backups, "")
+	cmdFlags.BoolVar(&flags.Backups, "ipv6", c.Config.Defaults.IPv6, "")
+	cmdFlags.BoolVar(&flags.PrivateNetworking, "private_networking", c.Config.Defaults.PrivateNetworking, "")
 
 	err := cmdFlags.Parse(args)
 
@@ -104,7 +110,10 @@ func (c *CreateCommand) Run(args []string) int {
 		SSHKeys: []godo.DropletCreateSSHKey{
 			{ID: key},
 		},
-		Image: image,
+		Image:             image,
+		Backups:           flags.Backups,
+		IPv6:              flags.IPv6,
+		PrivateNetworking: flags.PrivateNetworking,
 	}
 
 	newDroplet, _, err := c.Client.Droplets.Create(createRequest)

--- a/command/info.go
+++ b/command/info.go
@@ -18,19 +18,51 @@ func (c *InfoCommand) Help() string {
 Usage: godo-cli info [options]
 
 Options:
-  -id=int The id of the droplet (required)
+  -id=int The id of the droplet
+  -id=string The name of the droplet
+
 
 e.g.
-  godo-cli info -id=droplet id
+  droplet by id
+    godo-cli info -id=droplet id
+  droplet by name
+    godo-cli info -name=name
+
 `
 	return strings.TrimSpace(helpText)
+}
+
+func (c *InfoCommand) DropletById(id int) (*godo.Droplet, error) {
+	dropletRoot, _, err := c.Client.Droplets.Get(id)
+
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to request %v", err))
+		return nil, err
+	}
+
+	return dropletRoot.Droplet, nil
+
+}
+
+func (c *InfoCommand) DropletByName(name string) (*godo.Droplet, error) {
+
+	util := GodoUtil{Client: c.Client}
+	droplet, err := util.GetDropletByName(name)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return droplet, nil
 }
 
 func (c *InfoCommand) Run(args []string) int {
 	cmdFlags := flag.NewFlagSet("build", flag.ContinueOnError)
 
 	var id = 0
+	var name = ""
 	cmdFlags.IntVar(&id, "id", 0, "")
+	cmdFlags.StringVar(&name, "name", "", "")
 
 	err := cmdFlags.Parse(args)
 
@@ -39,14 +71,26 @@ func (c *InfoCommand) Run(args []string) int {
 		return -1
 	}
 
-	dropletRoot, _, err := c.Client.Droplets.Get(id)
+	if name == "" && id == 0 {
+		c.Help()
+		return -1
+	}
+
+	var droplet *godo.Droplet
+	if name != "" {
+		droplet, err = c.DropletByName(name)
+	} else {
+
+		if id != 0 {
+			droplet, err = c.DropletById(id)
+		}
+	}
 
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to request %v", err))
 		return -1
 	}
 
-	droplet := dropletRoot.Droplet
 	c.Ui.Output(fmt.Sprintf("%s (status: %s, region :%s, id: %d, image id:%d size:%s)\n",
 		droplet.Name, droplet.Status, droplet.Region.Slug, droplet.ID, droplet.Image.ID, droplet.Size.Slug))
 

--- a/config/config.go
+++ b/config/config.go
@@ -12,10 +12,13 @@ type Authentication struct {
 	APIKey string `yaml:"apikey"`
 }
 type Defaults struct {
-	Region string `yaml:"region"`
-	Image  string `yaml:"image"`
-	Size   string `yaml:"size"`
-	Key    string `yaml:"key"`
+	Region            string `yaml:"region"`
+	Image             string `yaml:"image"`
+	Size              string `yaml:"size"`
+	Key               string `yaml:"key"`
+	Backups           bool   `yaml:"backups"`
+	IPv6              bool   `yaml:"ipv6"`
+	PrivateNetworking bool   `yaml:"private_networking"`
 }
 
 type Config struct {


### PR DESCRIPTION
Oguni-san, I've created my first command power. It has three flags:

-Id and Name are the standard flags used by you to identify a droplet by id or name
-Mode = accepts off, on and cycle. Off is the default mode.

I've refactored some code to remove the need to create additional funds for PowerOff/On/CycleByName. I hope this enhancement is suitable.
